### PR TITLE
docs: add required permissions to workflow examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+
 jobs:
   check-robots:
     runs-on: ubuntu-latest
@@ -71,6 +76,11 @@ name: Only Robots Check
 on:
   pull_request:
     branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
 
 jobs:
   check-robots:


### PR DESCRIPTION
## Summary
- Added required permissions block to README workflow examples
- Ensures users configure proper GitHub permissions for the action to work correctly

## Changes
- Added `permissions` block with:
  - `contents: read` - Required for reading repository content
  - `pull-requests: write` - Required for creating PR comments
  - `checks: write` - Required for creating check runs

## Test plan
- The updated examples now match the required permissions for the action to function properly
- Users following the README will have a working configuration out of the box