### PR TITLE
feat: add comprehensive GitHub Action publish workflow

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -22,10 +22,24 @@ jobs:
         with:
           node-version: '20'
           
-      - name: Setup pnpm
+      - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 9
+          
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+      
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
           
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   check-dist:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 9
           
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -24,8 +24,6 @@ jobs:
           
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
           
       - name: Get pnpm store directory
         id: pnpm-cache

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -1,0 +1,49 @@
+name: Check dist/
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-dist:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8
+          
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        
+      - name: Build the action
+        run: pnpm run build
+        
+      - name: Compare the expected and actual dist/ directories
+        run: |
+          if [ "$(git diff --ignore-space-at-eol dist/ | wc -l)" -gt "0" ]; then
+            echo "Detected uncommitted changes after build. See status below:"
+            git diff --name-only
+            git diff
+            echo "Run 'pnpm run build' and commit the changes"
+            exit 1
+          fi
+        id: diff
+        
+      - name: Upload dist/ artifacts
+        uses: actions/upload-artifact@v4
+        if: failure() && steps.diff.conclusion == 'failure'
+        with:
+          name: dist
+          path: dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,81 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8
+          
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        
+      - name: Build the action
+        run: pnpm run build
+        
+      - name: Run tests
+        run: pnpm run test
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          
+      - name: Run type checking
+        run: pnpm run typecheck
+        
+      - name: Run linting
+        run: pnpm run lint
+        
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG_NAME="${{ github.event.release.tag_name }}"
+          VERSION=${TAG_NAME#v}
+          MAJOR_VERSION=$(echo $VERSION | cut -d. -f1)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "major_version=v$MAJOR_VERSION" >> $GITHUB_OUTPUT
+          echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
+          
+      - name: Update package.json version
+        run: |
+          npm version ${{ steps.version.outputs.version }} --no-git-tag-version
+          
+      - name: Rebuild with updated version
+        run: pnpm run build
+        
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          
+      - name: Commit built files
+        run: |
+          git add dist/ package.json
+          git commit -m "Release ${{ steps.version.outputs.tag_name }}"
+          
+      - name: Create or update major version tag
+        run: |
+          git tag -f ${{ steps.version.outputs.major_version }} ${{ steps.version.outputs.tag_name }}
+          git push origin ${{ steps.version.outputs.major_version }} --force
+          
+      - name: Push changes to release tag
+        run: |
+          git tag -f ${{ steps.version.outputs.tag_name }}
+          git push origin ${{ steps.version.outputs.tag_name }} --force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,24 @@ jobs:
         with:
           node-version: '20'
           
-      - name: Setup pnpm
+      - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 9
+          
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+      
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
           
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,6 @@ jobs:
           
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
           
       - name: Get pnpm store directory
         id: pnpm-cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 9
           
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,12 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
       
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,6 @@ jobs:
       
       - name: Install pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
       
       - name: Get pnpm store directory
         id: pnpm-cache

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -18,11 +18,12 @@ on:
           - v4
           - v5
 
+permissions:
+  contents: write
+
 jobs:
   update-version:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
       
     steps:
       - name: Checkout

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -1,0 +1,52 @@
+name: Update Version Tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'The tag or reference to use'
+        required: true
+        type: string
+      major_version:
+        description: 'The major version to update'
+        required: true
+        type: choice
+        options:
+          - v1
+          - v2
+          - v3
+          - v4
+          - v5
+
+jobs:
+  update-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          
+      - name: Validate target reference
+        run: |
+          if ! git show-ref --verify --quiet refs/tags/${{ github.event.inputs.target }}; then
+            echo "Error: Tag ${{ github.event.inputs.target }} does not exist"
+            exit 1
+          fi
+          
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          
+      - name: Update major version tag
+        run: |
+          git tag -f ${{ github.event.inputs.major_version }} ${{ github.event.inputs.target }}
+          git push origin ${{ github.event.inputs.major_version }} --force
+          
+      - name: Summary
+        run: |
+          echo "✅ Successfully updated ${{ github.event.inputs.major_version }} to point to ${{ github.event.inputs.target }}"

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,0 +1,143 @@
+# Publishing Workflow
+
+This document describes how to publish new versions of the Only Robots GitHub Action.
+
+## Overview
+
+The action follows semantic versioning and uses a multi-tag system similar to other popular GitHub Actions:
+
+- **Specific version tags**: `v1.0.0`, `v1.1.0`, `v1.1.1` (immutable, points to exact commit)
+- **Major version tags**: `v1`, `v2`, `v3` (mutable, points to latest release within major version)
+
+## Publishing Process
+
+### 1. Automated Publishing (Recommended)
+
+The automated publishing workflow is triggered when you create a GitHub release:
+
+1. **Create a GitHub Release**:
+   - Go to the [Releases page](https://github.com/dcramer/action-onlyrobots/releases)
+   - Click "Create a new release"
+   - Tag version: `v1.0.0` (use semantic versioning)
+   - Generate release notes or write them manually
+   - Click "Publish release"
+
+2. **Automatic Processing**:
+   - The `release.yml` workflow will automatically:
+     - Build the action
+     - Run tests and linting
+     - Update package.json version
+     - Commit built files to the release tag
+     - Update the major version tag (e.g., `v1` → `v1.0.0`)
+
+### 2. Manual Version Tag Updates
+
+If you need to manually update a major version tag to point to a different release:
+
+1. Go to the [Actions tab](https://github.com/dcramer/action-onlyrobots/actions)
+2. Select "Update Version Tag" workflow
+3. Click "Run workflow"
+4. Enter:
+   - **Target**: The existing tag to point to (e.g., `v1.0.1`)
+   - **Major version**: The major version to update (e.g., `v1`)
+
+## Workflow Files
+
+### `.github/workflows/check-dist.yml`
+- Runs on push/PR to main
+- Ensures compiled `dist/` directory is up-to-date
+- Prevents merging code without proper build artifacts
+
+### `.github/workflows/release.yml`
+- Runs when a GitHub release is published
+- Builds, tests, and publishes the action
+- Updates major version tags automatically
+
+### `.github/workflows/update-version.yml`
+- Manual workflow for updating major version tags
+- Useful for hotfixes or corrections
+
+## Pre-Release Checklist
+
+Before creating a release:
+
+1. **Ensure all changes are merged to main**
+2. **Run local validation**:
+   ```bash
+   pnpm run validate
+   ```
+3. **Test the action locally**:
+   ```bash
+   pnpm run test-pr
+   ```
+4. **Verify dist/ is up-to-date**:
+   ```bash
+   pnpm run build
+   git status  # should show no changes in dist/
+   ```
+
+## Version Strategy
+
+### Major Versions (v1, v2, v3)
+- Breaking changes
+- New required inputs
+- Removed functionality
+- Major workflow changes
+
+### Minor Versions (v1.1, v1.2)
+- New features
+- New optional inputs
+- Enhanced functionality
+- Non-breaking changes
+
+### Patch Versions (v1.1.1, v1.1.2)
+- Bug fixes
+- Security patches
+- Documentation updates
+- Performance improvements
+
+## User Consumption
+
+Users can reference the action in multiple ways:
+
+```yaml
+# Recommended: Use major version (gets latest patches automatically)
+- uses: dcramer/action-onlyrobots@v1
+
+# Specific version (locked to exact release)
+- uses: dcramer/action-onlyrobots@v1.0.0
+
+# Development version (not recommended for production)
+- uses: dcramer/action-onlyrobots@main
+```
+
+## Troubleshooting
+
+### Build Artifacts Out of Date
+If the `check-dist.yml` workflow fails:
+```bash
+pnpm run build
+git add dist/
+git commit -m "Update build artifacts"
+```
+
+### Release Workflow Fails
+1. Check that `OPENAI_API_KEY` is set in repository secrets
+2. Verify the tag follows semantic versioning (e.g., `v1.0.0`)
+3. Ensure all tests pass locally with `pnpm run test`
+
+### Major Version Tag Issues
+If a major version tag points to the wrong release:
+1. Use the "Update Version Tag" workflow
+2. Or manually update via CLI:
+   ```bash
+   git tag -f v1 v1.0.1
+   git push origin v1 --force
+   ```
+
+## Security Notes
+
+- Only repository maintainers can create releases
+- All builds are performed in GitHub Actions (not local machines)
+- Secrets are only accessible to the release workflow
+- Built artifacts are committed to release tags, not main branch

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "build:clean": "rm -rf dist && pnpm run build",
     "start": "node dist/cli.js",
     "test-pr": "tsx src/test-cli.ts",
     "typecheck": "tsc --noEmit",
@@ -16,7 +17,9 @@
     "lint:fix": "pnpm run typecheck && biome lint --fix",
     "prepare": "simple-git-hooks",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "validate": "pnpm run typecheck && pnpm run lint && pnpm run test",
+    "package": "pnpm run build:clean && pnpm run validate"
   },
   "keywords": [],
   "author": "David Cramer <dcramer@gmail.com> (https://github.com/dcramer)",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "keywords": [],
   "author": "David Cramer <dcramer@gmail.com> (https://github.com/dcramer)",
   "license": "Apache-2.0",
+  "packageManager": "pnpm@9.5.0",
   "devDependencies": {
     "@biomejs/biome": "^2.1.1",
     "@types/node": "^24.0.14",


### PR DESCRIPTION
## Summary

This PR adds a complete publishing workflow for the Only Robots GitHub Action, following best practices from popular actions like `actions/checkout` and `actions/setup-node`.

### Key Features Added:

- **Automated Release Workflow** (`release.yml`): Triggered by GitHub releases, handles building, testing, and version tagging
- **Build Validation Workflow** (`check-dist.yml`): Ensures compiled `dist/` directory is always up-to-date on PRs/pushes
- **Manual Version Update Workflow** (`update-version.yml`): Allows manual updates to major version tags
- **Enhanced Package Scripts**: Added `build:clean`, `validate`, and `package` commands
- **Comprehensive Documentation**: Complete publishing guide in `PUBLISHING.md`

### Publishing Strategy:

- **Semantic Versioning**: `v1.0.0`, `v1.1.0`, `v1.1.1`
- **Multi-Tag System**: Both specific (`v1.0.0`) and major (`v1`) version tags
- **Quality Gates**: All releases must pass build, tests, and linting
- **User-Friendly**: Users can reference `@v1` for automatic patches or `@v1.0.0` for locked versions

### Workflow Process:

1. **Create GitHub Release** with semantic version tag (e.g., `v1.0.0`)
2. **Automated Processing**: Build, test, validate, and update version tags
3. **Users Reference**: `uses: getsentry/action-onlyrobots@v1` or `@v1.0.0`

## Test Plan

- [x] All existing tests pass (`pnpm run test`)
- [x] TypeScript compilation works (`pnpm run typecheck`)
- [x] Linting passes (`pnpm run lint`)
- [x] Build process works (`pnpm run build:clean`)
- [x] New validation script works (`pnpm run validate`)
- [ ] Test release workflow with a pre-release
- [ ] Verify `OPENAI_API_KEY` secret is configured

## Breaking Changes

None. This is purely additive infrastructure for publishing.

## Next Steps

1. Merge this PR
2. Ensure `OPENAI_API_KEY` is set in repository secrets
3. Create first release (`v1.0.0`) to establish baseline
4. Test the complete workflow end-to-end