### PR TITLE
fix: reset package.json version to 0.0.0 and update release command

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,14 @@
+Create a new release of this GitHub Action
+
+Follow the instructions in PUBLISHING.md to create a new release of this project.
+
+You should simply do a minor version bump. e.g. if the current release is v1.0.0, the next release should be v1.1.0.
+
+To identify the current release, use the GitHub CLI to check the latest release:
+```bash
+gh release view --json tagName --jq .tagName
+```
+
+If no releases exist yet, the first release should be v1.0.0.
+
+IF YOU CANNOT IDENTIFY THE CURRENT RELEASE, THEN YOU SHOULD ABORT.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "action-onlyrobots",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "GitHub Action to ensure code is written by AI agents, not humans",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
## Summary
- Reset package.json version to 0.0.0 since versions are managed on release tags
- Update the release command to find current version from GitHub releases instead of package.json

## Why this change?
The release workflow updates package.json version on the release tag, not on the main branch. This is a common pattern for GitHub Actions where:
- The main branch stays at a development version (0.0.0)
- Each release tag contains the correct version in package.json
- Users consume the action via tags (@v1, @v1.0.0)

This change aligns the codebase with this workflow pattern.

## Test plan
- [x] Run `pnpm run build` to ensure the package builds correctly
- [x] The release command now uses `gh release view` to find the current version